### PR TITLE
chore: complete .dxt to .mcpb migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ https://github.com/user-attachments/assets/746b8535-f8b2-4ffa-828c-7b39fbf6650b
 
 ### Claude Desktop
 
-#### (Recommended) Alternative: Via manual .dxt installation
+#### (Recommended) Alternative: Via manual .mcpb installation
 
-1. Find the latest dxt build in [the GitHub Actions history](https://github.com/domdomegg/downdetector-mcp/actions/workflows/dxt.yaml?query=branch%3Amaster) (the top one)
-2. In the 'Artifacts' section, download the `mcp-server-dxt` file
-3. Rename the `.zip` file to `.dxt`
-4. Double-click the `.dxt` file to open with Claude Desktop
+1. Find the latest mcpb build in [the GitHub Actions history](https://github.com/domdomegg/downdetector-mcp/actions/workflows/ci.yaml?query=branch%3Amaster) (the top one)
+2. In the 'Artifacts' section, download the `downdetector-mcp-mcpb` file
+3. Rename the `.zip` file to `.mcpb`
+4. Double-click the `.mcpb` file to open with Claude Desktop
 5. Click "Install"
 
 #### (Advanced) Alternative: Via JSON configuration

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -134,20 +134,20 @@ describe.each([
 		},
 	},
 	{
-		name: 'DXT Package',
-		condition: process.env.RUN_DXT_TEST,
+		name: 'MCP Bundle',
+		condition: process.env.RUN_MCPB_TEST,
 		async createClient(): Promise<MCPClient> {
-			// Build DXT package if it doesn't exist
-			if (!existsSync('mcp-server.dxt')) {
-				execSync('./build-dxt.sh', {stdio: 'inherit'});
+			// Build MCP Bundle if it doesn't exist
+			if (!existsSync('downdetector-mcp.mcpb')) {
+				execSync('./build-mcpb.sh', {stdio: 'inherit'});
 			}
 
-			// Extract DXT package to test directory
-			const testDir = 'test-dxt-client';
+			// Extract MCP Bundle to test directory
+			const testDir = 'test-mcpb-client';
 			execSync(`rm -rf ${testDir}`);
-			execSync(`mkdir -p ${testDir} && unzip -q mcp-server.dxt -d ${testDir}`);
+			execSync(`mkdir -p ${testDir} && unzip -q downdetector-mcp.mcpb -d ${testDir}`);
 
-			// Start the MCP server from the extracted DXT package
+			// Start the MCP server from the extracted MCP Bundle
 			const serverProcess = spawn('node', [path.join(testDir, 'dist/index.js')], {
 				stdio: ['pipe', 'pipe', 'pipe'],
 				env: {...process.env},


### PR DESCRIPTION
Updates the README install instructions and the `RUN_DXT_TEST`-gated e2e test to use the `.mcpb` format and current artifact/script names. Same class of staleness as domdomegg/computer-use-mcp#65/#67 — the build script and CI already produce `.mcpb` artifacts but the docs and test still referenced `.dxt`.